### PR TITLE
feat: mark done if GH action run was canceled

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,9 @@
 
     if (item.url.match('/pull/[0-9]+/files/'))
       return 'New commit pushed to PR'
+
+    if (item.type === 'ci activity' && /workflow run cancell?ed/.test(item.title))
+        return 'GH PR Audit Action workflow run cancelled, probably due to another run taking precedence'
   }
 
   function autoMarkDone() {


### PR DESCRIPTION
## Test Plan

have a github action cancel a workflow run. The notification should get auto-marked done